### PR TITLE
feat: add landing page package

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+    append_view_path(Dir.glob(Rails.root.join('app/packages/*/views')))
 end

--- a/app/packages/landing/controllers/landing_controller.rb
+++ b/app/packages/landing/controllers/landing_controller.rb
@@ -1,0 +1,4 @@
+class LandingController < ApplicationController
+  def index
+  end
+end

--- a/app/packages/landing/helpers/landing_helper.rb
+++ b/app/packages/landing/helpers/landing_helper.rb
@@ -1,0 +1,2 @@
+module LandingHelper
+end

--- a/app/packages/landing/package.yml
+++ b/app/packages/landing/package.yml
@@ -1,0 +1,13 @@
+# Turn on dependency checks for this package
+enforce_dependencies: true
+
+# Turn on privacy checks for this package
+enforce_privacy: true
+
+# this allows you to modify what your package's public path is within the package
+public_path: public/
+
+# A list of this package's dependencies
+# Note that packages in this list require their own  file
+dependencies:
+- '.'

--- a/app/packages/landing/views/landing/index.html.erb
+++ b/app/packages/landing/views/landing/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Landing#index Modular</h1>
+<p>Find me in app/packages/landing/views/landing/index.html.erb</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,8 @@ module RailsPack
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+    
+    # config packages fur packwerk
+    config.paths.add 'app/packages', glob: '*/{*,*/concerns}', eager_load: true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'landing/index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
@@ -7,4 +8,5 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
+  root "landing#index"
 end


### PR DESCRIPTION
# What
- Add package landing page

# How
1. Configure Packages in config/application.rb add:

`config.paths.add 'app/packages', glob: '*/{*,*/concerns}', eager_load: true`

2. Also change app/controllers/application_controller.rb to:
```
# app/controllers/application_controller.rb
class ApplicationController < ActionController::Base
  append_view_path(Dir.glob(Rails.root.join('app/packages/*/views')))
end
```

3. Finally, lets create the location for the packages:
`mkdir app/packages`


4. Create a landing page
We can generate the code using:
`bin/rails g controller landing index`

5. Move to app/packages/landing
![Screenshot 2024-05-03 at 05 56 33](https://github.com/Minhchau0108/learning-packwerb/assets/74655110/9b570bfd-f74e-4a30-af10-7bee1004e423)

6. Create package.yml to configure the package
```
# Turn on dependency checks for this package
enforce_dependencies: true

# Turn on privacy checks for this package
enforce_privacy: true

# this allows you to modify what your package's public path is within the package
public_path: public/

# A list of this package's dependencies
# Note that packages in this list require their own  file
dependencies:
- '.'

```

7. Now finally, the update the routing:
```
Rails.application.routes.draw do
  get 'landing/index'
  root "landing#index"
end
```

8. lets try the packwerk check to see if we have clearly defined our package:
`bin/packwerk check`